### PR TITLE
Intel MKL backend

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -22,6 +22,7 @@ default = ["openblas"]
 accelerate = ["accelerate-src"]
 netlib = ["netlib-src"]
 openblas = ["openblas-src"]
+intel-mkl = ["intel-mkl-src"]
 
 [dependencies]
 libc = "0.2"
@@ -36,4 +37,8 @@ optional = true
 
 [dependencies.openblas-src]
 version = "0.5"
+optional = true
+
+[dependencies.intel-mkl-src]
+version = "0.2.5"
 optional = true

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -14,6 +14,9 @@ extern crate netlib_src as raw;
 #[cfg(feature = "openblas")]
 extern crate openblas_src as raw;
 
+#[cfg(feature = "intel-mkl")]
+extern crate intel_mkl_src as raw;
+
 /// A complex number with 64-bit parts.
 #[allow(bad_style)]
 pub type c_double_complex = [libc::c_double; 2];


### PR DESCRIPTION
Same as https://github.com/stainless-steel/lapack-sys/pull/8
Link to Intel MKL using [intel-mkl-src](https://github.com/termoshtt/rust-intel-mkl) which re-distribute Intel MKL under its original license.