### PR TITLE
Support for f16 hgemm.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "blas-sys"
-version = "0.7.1"
+version = "0.7.2"
 license = "Apache-2.0/MIT"
 authors = [
     "Andrew Straw <strawman@astraw.com>",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,3 +18,7 @@ keywords = ["linear-algebra"]
 
 [dependencies]
 libc = "0.2"
+half = {version="2.3.1", optional=true}
+
+[features]
+half = ["dep:half"]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1436,4 +1436,22 @@ extern "C" {
         b: *mut c_double_complex,
         ldb: *const c_int,
     );
+
+    // Half
+    #[cfg(feature = "half")]
+    pub fn hgemm_(
+        transa: *const c_char,
+        transb: *const c_char,
+        m: *const c_int,
+        n: *const c_int,
+        k: *const c_int,
+        alpha: *const half::f16,
+        a: *const half::f16,
+        lda: *const c_int,
+        b: *const half::f16,
+        ldb: *const c_int,
+        beta: *const half::f16,
+        c: *mut half::f16,
+        ldc: *const c_int,
+    );
 }


### PR DESCRIPTION
As mentioned in https://github.com/blas-lapack-rs/blas/issues/41, it would be convenient to support half-precision gemm when using mkl.
This PR adds it on the sys side behind a dedicated feature gate.
More details on the [associated blas PR](https://github.com/blas-lapack-rs/blas/pull/42).